### PR TITLE
Use admin container during PrestaShop installation

### DIFF
--- a/src/DependencyInjection/ServiceContainer.php
+++ b/src/DependencyInjection/ServiceContainer.php
@@ -76,6 +76,6 @@ class ServiceContainer
         );
         $containerProvider = new ContainerProvider($this->moduleName, $this->moduleLocalPath, $cacheDirectory);
 
-        $this->container = $containerProvider->get(defined('_PS_ADMIN_DIR_') ? 'admin' : 'front');
+        $this->container = $containerProvider->get(defined('_PS_ADMIN_DIR_') || defined('PS_INSTALLATION_IN_PROGRESS') ? 'admin' : 'front');
     }
 }


### PR DESCRIPTION
On PrestaShop installation, some modules are installed outside of PrestaShop BO so `_PS_ADMIN_DIR_` is not defined but `PS_INSTALLATION_IN_PROGRESS` is defined.
So if `PS_INSTALLATION_IN_PROGRESS` is defined we should use admin container to have services related to module installation